### PR TITLE
Added an easier way to set the testconfiguration.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,9 @@ Create a steps file in your project and load the api teststeps from there and ad
 ```js
 module.exports = function myCustomSteps() {
     require('minosse').call(this);
-    this.Before(function loadTestConfig(done) {
-        this.testConfig = {
-            defaultHost: 'localhost',
-            defaultPort: 8080
-        };
-        done();
+    this.setTestConfig({
+        defaultHost: 'localhost',
+        defaultPort: 8080
     });
 }
 ```

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -10,6 +10,10 @@ module.exports = function apiTestSteps() {
         this.World.prototype._log = bunyan.createLogger(options);
     };
 
+    this.setTestConfig = function setTestConfig(config) {
+        this.World.prototype.testConfig = config;
+    };
+
     this.createLogger({
         name: 'test-steps',
         streams: []

--- a/test/property-steps.feature
+++ b/test/property-steps.feature
@@ -75,7 +75,6 @@ Feature: setting and checking properties
         Then I check property foo equals property bar
 
     Scenario: Loading testdata from file
-        Given [TEST] testDataRoot path is configured
         When I set property foo to testdata foo
         Then [TEST] I assert property foo.nr equals 42
 

--- a/test/steps/property-steps.steps.js
+++ b/test/steps/property-steps.steps.js
@@ -4,10 +4,8 @@ var format = require('util').format;
 var moment = require('moment');
 
 module.exports = function propertyStepsSteps() {
-    this.Given('[TEST] testDataRoot path is configured', function(done) {
-        this.testConfig = this.testConfig || {};
-        this.testConfig.testDataRoot = path.join(__dirname, '../data');
-        done();
+    this.setTestConfig({
+        testDataRoot: path.join(__dirname, '../data')
     });
 
     /* eslint-disable no-eval */


### PR DESCRIPTION
Previously, the recommended way of doing this was to manually set
the configuration in a Before hook. I added a function that can be
called to set the testConfig directly on the world prototype.

The README.md was adapted to reflect this change.