### PR TITLE
Fixed issue #8: Logging req.body.

### DIFF
--- a/lib/steps/debug-steps.js
+++ b/lib/steps/debug-steps.js
@@ -14,7 +14,7 @@ module.exports = function apiSteps() {
 
     this.Then(/^DEBUG I eval (.+)$/, function(evalString, done) {
         global.assert = require('assert');
-        eval.call(this, evalString); //jshint ignore:line
+        eval.call(this, evalString);
         done();
     });
 };

--- a/lib/steps/http-steps.js
+++ b/lib/steps/http-steps.js
@@ -9,13 +9,13 @@ module.exports = function httpSteps() {
 
         createEmptyRequest.call(this);
 
-        //Make 'request body' a proxy for req.json.
+        //Make 'request body' a proxy for req.body.
         Object.defineProperty(this, 'request body', {
             get: function getBody() {
-                return _this.req.json;
+                return _this.req.body;
             },
             set: function setBody(body) {
-                _this.req.json = body;
+                _this.req.body = body;
             }
         });
 
@@ -33,7 +33,7 @@ module.exports = function httpSteps() {
 
     function createEmptyRequest() {
         this.req = {
-            json: {},
+            body: {},
             headers: {}
         };
     }
@@ -68,6 +68,7 @@ module.exports = function httpSteps() {
         uri.hostname = uri.host || testConfig.defaultHost || 'localhost';
         uri.port = uri.port || testConfig.defaultPort || 8080;
         this.req = this.req || {};
+        this.req.json = true;
         this.req.method = httpMethod;
         this.req.uri = url.format(uri);
         this._log.trace({ request: this.req }, 'Sending request.');


### PR DESCRIPTION
Because req.json was used internally as the object being prepared for
the request, logging req.body returned undefined. Switched to using
req.body, which is more in line with what people would expect.