### PR TITLE
Added parser for templateStrings.

### DIFF
--- a/lib/parsers.js
+++ b/lib/parsers.js
@@ -1,3 +1,4 @@
+var _ = require('lodash');
 var moment = require('moment');
 var path = require('path');
 var util = require('util');
@@ -14,7 +15,8 @@ var typeMap = {
     'null': function () { return null; },
     'property': parseProperty,
     'uuid()': require('node-uuid').v4,
-    'testdata': loadTestData
+    'testdata': loadTestData,
+    'templateString': parseTemplateString
 };
 
 //Add aliases
@@ -95,4 +97,14 @@ function loadTestData(fileName) {
     }
     this._log.trace({ loadedData: value }, 'File loaded.');
     return value;
+}
+
+var INTERPOLATION_REGEX = /{(.+?)}/g;
+function parseTemplateString(templateString) {
+    if (typeof templateString === 'undefined') {
+        return '';
+    }
+    var compiled = _.template(templateString, null, { interpolate: INTERPOLATION_REGEX });
+    var valueString = compiled(this);
+    return valueString;
 }

--- a/test/property-steps.feature
+++ b/test/property-steps.feature
@@ -34,6 +34,11 @@ Feature: setting and checking properties
             | foo      | null      |
             | foo      | undefined |
 
+    Scenario: Setting a property to a template string
+        When I set property end to string bar
+        When I set property total to templateString foo{end}
+        Then [TEST] I assert property total equals 'foobar'
+
     Scenario Outline: Checking a property
         When [TEST] I set <property> to <actual value>
         Then I check property <property> equals <expected type> <expected value>
@@ -63,6 +68,11 @@ Feature: setting and checking properties
             | property | value     |
             | foo      | null      |
             | foo      | undefined |
+
+    Scenario: Checking a property using a template string
+        Given [TEST] I set total to 'foobar'
+        And [TEST] I set end to 'bar'
+        Then I check property total equals templateString foo{end}
 
     Scenario: Setting a property to the value of another property
         Given [TEST] I set bar to 42


### PR DESCRIPTION
It is possible to set or check a property as a templateString. Inside a
template string, placeholders of the form '{foo}' will be replaced with
the value of the property foo.

This resolves #7.