### PR TITLE
extend request headers when set

### DIFF
--- a/lib/steps/http-steps.js
+++ b/lib/steps/http-steps.js
@@ -3,6 +3,7 @@ var assert = require('assert');
 var request = require('request');
 var async = require('async');
 var objTree = require('../obj-tree');
+var _ = require('lodash');
 
 var JSON_TYPE = 'application/json';
 var FORM_TYPE = 'multipart/formdata';
@@ -29,7 +30,7 @@ module.exports = function httpSteps() {
                 return _this.req.headers;
             },
             set: function setHeaders(headers) {
-                _this.req.headers = headers;
+                _this.req.headers = _.extend(_this.req.headers, headers);
             }
         });
         done();
@@ -153,7 +154,6 @@ module.exports = function httpSteps() {
 
     function parseForContentType(req) {
         var headers = req.headers;
-
         if (!headers['Content-Type'] || headers['Content-Type'] === JSON_TYPE) {
             req.json = true;
         } else if (headers['Content-Type'] === FORM_TYPE) {


### PR DESCRIPTION
Extending request headers is necessary because if you do an explicit set with:
``` cucumber
And I set request headers to property foomartheaders
```

Would overwrite any headers (like content-type) already set.