### PR TITLE
Take Content-Type into consideration when doing a GET

### DIFF
--- a/lib/steps/http-steps.js
+++ b/lib/steps/http-steps.js
@@ -38,8 +38,7 @@ module.exports = function httpSteps() {
     function createEmptyRequest() {
         this.req = {
             body: {},
-            headers: {},
-            encoding: null
+            headers: {}
         };
     }
 
@@ -146,15 +145,21 @@ module.exports = function httpSteps() {
     });
 
     function parseForContentType(req) {
-        if (req.method === 'GET') {
+        var headers = req.headers;
+        var contentType = headers['Content-Type'];
+
+        // We are making a GET Request, e.g. for Images and we have no content type set
+        // this will make the request module send us back a buffer.
+        if (req.method === 'GET' && !contentType) {
             delete req.body;
+            req.encoding = null;
             return;
         }
 
-        var headers = req.headers;
-        if (!headers['Content-Type'] || headers['Content-Type'] === JSON_TYPE) {
+
+        if (!contentType || contentType === JSON_TYPE) {
             req.json = true;
-        } else if (headers['Content-Type'] === FORM_TYPE) {
+        } else if (contentType === FORM_TYPE) {
             req.formData = req.body;
             delete req.body;
         } else {

--- a/lib/steps/http-steps.js
+++ b/lib/steps/http-steps.js
@@ -38,7 +38,8 @@ module.exports = function httpSteps() {
     function createEmptyRequest() {
         this.req = {
             body: {},
-            headers: {}
+            headers: {},
+            json: true
         };
     }
 
@@ -87,7 +88,7 @@ module.exports = function httpSteps() {
         this.req.uri = url.format(uri);
 
         // set JSON true or parse file to be formData as request expects the formData like that.
-        parseForContentType(this.req);
+        decideContentType(this.req);
 
         this._log.trace({ request: this.req }, 'Sending request.');
 
@@ -144,26 +145,34 @@ module.exports = function httpSteps() {
         done();
     });
 
-    function parseForContentType(req) {
+    function decideContentType(req) {
         var headers = req.headers;
         var contentType = headers['Content-Type'];
 
-        // We are making a GET Request, e.g. for Images and we have no content type set
-        // this will make the request module send us back a buffer.
-        if (req.method === 'GET' && !contentType) {
-            delete req.body;
-            req.encoding = null;
+        checkAcceptHeaders(req);
+
+        if (!contentType) {
             return;
         }
 
-
-        if (!contentType || contentType === JSON_TYPE) {
-            req.json = true;
-        } else if (contentType === FORM_TYPE) {
-            req.formData = req.body;
-            delete req.body;
-        } else {
-            throw new Error('Unsupported header settings. We only support applcation/json or multipart/formdata.');
+        if (contentType === FORM_TYPE) {
+            parseFormData(req);
         }
+    }
+
+    function checkAcceptHeaders(req) {
+        var headers = req.headers || {};
+        var accept = headers.accept;
+
+        if (accept && accept !== JSON_TYPE) {
+            delete req.body;
+            req.encoding = null;
+        }
+    }
+
+    function parseFormData(req) {
+        req.formData = req.body;
+        req.json = false;
+        delete req.body;
     }
 };

--- a/lib/steps/http-steps.js
+++ b/lib/steps/http-steps.js
@@ -90,6 +90,10 @@ module.exports = function httpSteps() {
         // set JSON true or parse file to be formData as request expects the formData like that.
         decideContentType(this.req);
 
+        if (this.req.method === 'GET' && this.req.json === false) {
+            delete this.req.body;
+        }
+
         this._log.trace({ request: this.req }, 'Sending request.');
 
         request(this.req, function(err, res) {
@@ -162,10 +166,10 @@ module.exports = function httpSteps() {
 
     function checkAcceptHeaders(req) {
         var headers = req.headers || {};
-        var accept = headers.accept;
+        var accept = headers.Accept;
 
         if (accept && accept !== JSON_TYPE) {
-            delete req.body;
+            req.json = false;
             req.encoding = null;
         }
     }


### PR DESCRIPTION
Don't enforce the request library with encoding: null, if the
content type is set, so we can still get back JSON response.