### PR TITLE
fix incompatibility with latest cucumber-js

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -22,8 +22,8 @@
   "homepage": "https://github.com/icemobilelab/minosse",
   "dependencies": {
     "body-parser": "^1.12.2",
-    "cucumber": "^0.7.0",
+    "cucumber": "0.4.9",
     "express": "^4.12.2",
-    "minosse": "*"
+    "minosse": "file:../"
   }
 }

--- a/example/package.json
+++ b/example/package.json
@@ -22,8 +22,8 @@
   "homepage": "https://github.com/icemobilelab/minosse",
   "dependencies": {
     "body-parser": "^1.12.2",
-    "cucumber": "^0.4.8",
+    "cucumber": "^0.7.0",
     "express": "^4.12.2",
-    "minosse": "^1.1.0"
+    "minosse": "*"
   }
 }

--- a/example/package.json
+++ b/example/package.json
@@ -22,7 +22,7 @@
   "homepage": "https://github.com/icemobilelab/minosse",
   "dependencies": {
     "body-parser": "^1.12.2",
-    "cucumber": "0.4.9",
+    "cucumber": "0.7.0",
     "express": "^4.12.2",
     "minosse": "file:../"
   }

--- a/example/server.js
+++ b/example/server.js
@@ -7,28 +7,28 @@ var util = require('util');
 app.use(bodyParser.json());
 
 app.get('/', function (req, res) {
-    res.send(200, {
+    res.status(200).send({
         message: 'hello world'
     });
 });
 
 app.get('/hello/:name', function (req, res) {
     var greeting = util.format('hello %s', req.params.name);
-    res.send(200, {
+    res.status(200).send({
         message: greeting
     });
 });
 
 app.post('/hello', function (req, res) {
     var name = util.format(req.body.name);
-    res.send(200, {
+    res.status(200).send({
         name: name
     });
 });
 
 app.post('/hello/lastName', function (req, res) {
     var name = util.format(req.body.lastName);
-    res.send(200, {
+    res.status(200).send({
         lastName: name
     });
 });

--- a/example/test/steps/steps.js
+++ b/example/test/steps/steps.js
@@ -2,7 +2,7 @@ var path = require('path');
 
 module.exports = function myCustomSteps() {
     require('minosse').call(this);
-    this.Before(function loadTestConfig(done) {
+    this.Before(function loadTestConfig(scenario, done) {
         // minosse checks for `testConfig` for framework configuration
         this.testConfig = {
             // look here for request configs

--- a/lib/steps/http-steps.js
+++ b/lib/steps/http-steps.js
@@ -8,7 +8,7 @@ var JSON_TYPE = 'application/json';
 var FORM_TYPE = 'multipart/formdata';
 
 module.exports = function httpSteps() {
-    this.Before(function(done) {
+    this.Before(function(scenario, done) {
         var _this = this;
 
         createEmptyRequest.call(this);

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "homepage": "https://github.com/icemobilelab/minosse",
   "devDependencies": {
-    "cucumber": "^0.4.7",
+    "cucumber": "^0.7.0",
     "gulp": "^3.8.8",
     "gulp-eslint": "^0.11.1",
     "gulp-help": "^1.1.0",


### PR DESCRIPTION
this pull request fixes an incompatibility issue with cucumber-js latest version (0.7.0) which [chages the interface of Before statements](https://github.com/cucumber/cucumber-js/tree/v0.7.0#before-hooks) introducing the scenario as first argument and unfortunately this breaks the retro compatibility of the API