### PR TITLE
Added array member comparison step

### DIFF
--- a/lib/steps/property-steps.js
+++ b/lib/steps/property-steps.js
@@ -73,6 +73,46 @@ module.exports = function propertySteps() {
     });
 
     /**
+     * I compare the members of two arrays
+     */
+    this.Given(/^I check (?:property|the) (.+?) (only |)contains the members of (?:property|the) (\S+)$/,
+            function(actualPropertyString, onlyString, expectedPropertyString, done) {
+        this._log.info('Step: I check property %s %s contains the members of %s',
+            actualPropertyString, onlyString, expectedPropertyString);
+        var actual = this.getProperty(actualPropertyString);
+        var expected = this.getProperty(expectedPropertyString);
+
+        this._log.info({expected: expected}, 'Expected property');
+
+        // Check that we deal with arrays
+        if (!_.isArray(actual) && !_.isArray(expected)) {
+            this._log.debug({
+                actualIsArray: _.isArray(actual),
+                expectedIsArray: _.isArray(expected)
+            }, 'Conditions not met');
+            throw new Error('"Contains" step allow checks just on type array');
+        }
+
+        // if 'only' is specified, we check that the actual property only contains the expected properties
+        // otherwise, we check if the expected property members are present amongst possible other members
+        if (onlyString === 'only ') {
+            assert.equal(actual.length, expected.length, 'Properties do not have the same length');
+        }
+
+        var actualIndex;
+        expected.map(function (expectedValue) {
+            actualIndex = actual.indexOf(expectedValue);
+            assert.ok(actualIndex > -1, 'Expected member ' + expectedValue + ' not found in actual array');
+
+            assert.equal(actual[actualIndex], expectedValue,
+                'Expected array members are not equal to actual array members');
+
+        });
+
+        done();
+    });
+
+    /**
      * I check if a property shich is an Array or an Object contains a certain value
      */
     this.Given(/^I check (?:property|the) (.+?) contains an object with a property named (\S+) of (.+)$/,

--- a/lib/steps/property-steps.js
+++ b/lib/steps/property-steps.js
@@ -85,7 +85,7 @@ module.exports = function propertySteps() {
         this._log.info({expected: expected}, 'Expected property');
 
         // Check that we deal with arrays
-        if (!_.isArray(actual) && !_.isArray(expected)) {
+        if (!_.isArray(actual) || !_.isArray(expected)) {
             this._log.debug({
                 actualIsArray: _.isArray(actual),
                 expectedIsArray: _.isArray(expected)

--- a/lib/steps/property-steps.js
+++ b/lib/steps/property-steps.js
@@ -100,7 +100,8 @@ module.exports = function propertySteps() {
         }
 
         expected.forEach(function (expectedValue) {
-            assert.ok(~actual.indexOf(expectedValue), 'Expected member ' + expectedValue + ' not found in actual array');
+            assert.ok(~actual.indexOf(expectedValue),
+                'Expected member ' + expectedValue + ' not found in actual array');
         });
 
         done();

--- a/lib/steps/property-steps.js
+++ b/lib/steps/property-steps.js
@@ -99,14 +99,8 @@ module.exports = function propertySteps() {
             assert.equal(actual.length, expected.length, 'Properties do not have the same length');
         }
 
-        var actualIndex;
-        expected.map(function (expectedValue) {
-            actualIndex = actual.indexOf(expectedValue);
-            assert.ok(actualIndex > -1, 'Expected member ' + expectedValue + ' not found in actual array');
-
-            assert.equal(actual[actualIndex], expectedValue,
-                'Expected array members are not equal to actual array members');
-
+        expected.forEach(function (expectedValue) {
+            assert.ok(~actual.indexOf(expectedValue), 'Expected member ' + expectedValue + ' not found in actual array');
         });
 
         done();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minosse",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "description": "Common test steps for testing api's.",
   "main": "lib/steps.js",
   "scripts": {

--- a/test/property-steps.feature
+++ b/test/property-steps.feature
@@ -191,3 +191,13 @@ Feature: setting and checking properties
     Scenario: Using a custom formatter
         Given [TEST] I set foo to 12
         When I check property foo has format even
+
+    Scenario: Checking array members are same
+        Given [TEST] I set actualArray to ['minosse', 'member', 42, 'comparison', 'test']
+        And [TEST] I set expectedArray to ['comparison', 'test', 42, 'member', 'minosse']
+        Then I check property actualArray only contains the members of property expectedArray
+
+    Scenario: Checking array members are included
+        Given [TEST] I set actualArray to ['git', 43, 'minosse', 42, 'member', 'foo', 'bar', 'comparison', 'test']
+        And [TEST] I set expectedArray to ['comparison', 'test', 42, 'member', 'minosse']
+        Then I check property actualArray contains the members of property expectedArray


### PR DESCRIPTION
The purpose of this step is to check if an array contains members you expect. Order is not taken into account.

If you specify `only` in the step, it will also check that the `actual` and `expected` array have the same length. Together with comparing values this becomes a check to see if arrays are equal regardless of ordering.